### PR TITLE
Catch Glif RPC error via Basin HTTP API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,4 @@ DISCORD_WEBHOOK_TOKEN_INTERNAL=server_discord_webhook_token
 DISCORD_WEBHOOK_ID_EXTERNAL=server_discord_webhook_id
 DISCORD_WEBHOOK_TOKEN_EXTERNAL=server_discord_webhook_token
 PRIVATE_KEY=your_private_key
+NODE_ENV=development # or production

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -1,0 +1,44 @@
+# Used only on manual triggers in case Tableland supported chains are altered,
+# thus, resulting in the previous vault data having chains that should not be
+# used. It's a pseudo-migration because it just creates a fresh db that gets
+# written to the vault.
+name: Migrate vault data
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache node modules
+        id: cache-npm
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm install
+      - name: Build app
+        run: |
+          npm run build
+      - name: Run vault migration
+        run: |
+          npm run migrate
+        env:
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_WEBHOOK_ID_INTERNAL: ${{ secrets.DISCORD_WEBHOOK_ID_INTERNAL }}
+          DISCORD_WEBHOOK_TOKEN_INTERNAL: ${{ secrets.DISCORD_WEBHOOK_TOKEN_INTERNAL }}
+          DISCORD_WEBHOOK_ID_EXTERNAL: ${{ secrets.DISCORD_WEBHOOK_ID_EXTERNAL }}
+          DISCORD_WEBHOOK_TOKEN_EXTERNAL: ${{ secrets.DISCORD_WEBHOOK_TOKEN_EXTERNAL }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .DS_Store
 .env
 .env.local
+basin-config-dev.json

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ First, clone this repo:
 https://github.com/tablelandnetwork/discord-sql-logs
 ```
 
-To get started, run `npm install` and then `npm run build` command; this will compile the package to the `dist` directory. To run the app, you will need to set the following environment variables in your `.env` file, or a `.env.local` can be used for development and will take precedence.
+To get started, run `npm install` and then `npm run build` command; this will compile the package to the `dist` directory. To run the app, you will need to set the following environment variables in your `.env` file:
 
 - `DISCORD_BOT_TOKEN`: The Discord bot token comes from creating a bot in the Discord Developer Portal at [https://discord.com/developers/applications](https://discord.com/developers/applications) and getting a token under the `Bot` tab and `Reset Token` button.
 - `DISCORD_WEBHOOK_ID_<INTERNAL|EXTERNAL>`, `DISCORD_WEBHOOK_TOKEN_<INTERNAL|EXTERNAL>`: These webhook variables come from the server's URL of the webhook, which you create in the Discord channel settings: `https://discord.com/api/webhooks/DISCORD_WEBHOOK_ID/DISCORD_WEBHOOK_TOKEN`. Note that each webhook is for a different channel, and the bot will separate messages based on if they are tables that are part of applications build by the Tableland team.
@@ -38,13 +38,13 @@ Once those are set, you can run the app with `npm run start`, and it will start 
 
 ## Development
 
-Follow the steps in the [Usage](#usage) section to get started. In particular, you can set up a `.env.local` file with a `NODE_ENV=development` variable to run the bot in development mode, which will also run from the `src/` directory instead of the `dist/` directory. The development mode also requires you create a filename called `basin-config-dev.json` in the root directory with the same format as `basin-config.json` but with a different vault name.
+Follow the steps in the [Usage](#usage) section to get started. In particular, you can set up a `.env` file with a `NODE_ENV=development` variable to run the bot in development mode, which will also run from the `src/` directory instead of the `dist/` directory. The development mode also requires you create a filename called `basin-config-dev.json` in the root directory with the same format as `basin-config.json` but with a different vault name.
 
 There are also a few other commands you can use:
 
 - `npm run build`: Compile the package to the `dist` directory.
 - `npm run start`: Start the bot.
-- `npm run dev`: Start the bot with development settings defined in `.env.local` and build from `src/`.
+- `npm run dev`: Start the bot with development settings defined in `.env` and build from `src/`.
 - `npm run lint`: Lint the codebase with `eslint` (along with the `lint:fix` option).
 - `npm run prettier`: Prettify the code format with `prettier` (along with the `prettier:fix` option).
 - `npm run format`: Both lint and format the codebase with `eslint` and `prettier`, also fixing any issues it can.

--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ First, clone this repo:
 https://github.com/tablelandnetwork/discord-sql-logs
 ```
 
-To get started, run `npm install` and then `npm run build` command; this will compile the package to the `dist` directory. To run the app, you will need to set the following environment variables in your `.env` file:
+To get started, run `npm install` and then `npm run build` command; this will compile the package to the `dist` directory. To run the app, you will need to set the following environment variables in your `.env` file, or a `.env.local` can be used for development and will take precedence.
 
 - `DISCORD_BOT_TOKEN`: The Discord bot token comes from creating a bot in the Discord Developer Portal at [https://discord.com/developers/applications](https://discord.com/developers/applications) and getting a token under the `Bot` tab and `Reset Token` button.
-- `DISCORD_WEBHOOK_ID`, `DISCORD_WEBHOOK_TOKEN`: These webhook variables come from the server's URL of the webhook, which you create in the Discord channel settings: `https://discord.com/api/webhooks/DISCORD_WEBHOOK_ID/DISCORD_WEBHOOK_TOKEN`
+- `DISCORD_WEBHOOK_ID_<INTERNAL|EXTERNAL>`, `DISCORD_WEBHOOK_TOKEN_<INTERNAL|EXTERNAL>`: These webhook variables come from the server's URL of the webhook, which you create in the Discord channel settings: `https://discord.com/api/webhooks/DISCORD_WEBHOOK_ID/DISCORD_WEBHOOK_TOKEN`. Note that each webhook is for a different channel, and the bot will separate messages based on if they are tables that are part of applications build by the Tableland team.
 - `PRIVATE_KEY`: A private key for creating and writing to a Basin vault, which stores the SQLite database (retrieves it before each run, writes the database to the vault after each run).
+- `NODE_ENV`: Optional, but can be set to `development` to run the bot in development mode. Otherwise, it will run in production mode.
 
 A vault name must be set in the `basin-config.json` file and is then created for the private key provided, which also signs subsequent writes to the vault. For example, this bot uses the `sql_logs_bot_state.db` vault, but keep in mind that **vault names must be unique and cannot be reused**. If you'd like to see the events for this vault, it's owned by `0xc2c3d5FFB6d60FFA48abBAFadCEfDf2bD4FD1905` and [viewable here](https://basin.tableland.xyz/vaults/sql_logs_bot_state.db/events).
 
@@ -37,10 +38,13 @@ Once those are set, you can run the app with `npm run start`, and it will start 
 
 ## Development
 
-Follow the steps in the [Usage](#usage) section to get started. There are also a few other commands you can use:
+Follow the steps in the [Usage](#usage) section to get started. In particular, you can set up a `.env.local` file with a `NODE_ENV=development` variable to run the bot in development mode, which will also run from the `src/` directory instead of the `dist/` directory. The development mode also requires you create a filename called `basin-config-dev.json` in the root directory with the same format as `basin-config.json` but with a different vault name.
+
+There are also a few other commands you can use:
 
 - `npm run build`: Compile the package to the `dist` directory.
 - `npm run start`: Start the bot.
+- `npm run dev`: Start the bot with development settings defined in `.env.local` and build from `src/`.
 - `npm run lint`: Lint the codebase with `eslint` (along with the `lint:fix` option).
 - `npm run prettier`: Prettify the code format with `prettier` (along with the `prettier:fix` option).
 - `npm run format`: Both lint and format the codebase with `eslint` and `prettier`, also fixing any issues it can.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
-        "@tableland/sdk": "^5.2.0",
+        "@tableland/sdk": "^6.0.0",
         "better-sqlite3": "^9.4.1",
         "discord.js": "^14.14.1",
         "dotenv": "^16.4.5",
@@ -35,6 +35,7 @@
         "prettier": "^3.0.3",
         "tempy": "^3.1.0",
         "ts-node": "^10.9.2",
+        "tsx": "^4.7.2",
         "typescript": "^5.3.3"
       }
     },
@@ -193,6 +194,374 @@
       "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w==",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1137,9 +1506,9 @@
       }
     },
     "node_modules/@tableland/evm": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-4.5.1.tgz",
-      "integrity": "sha512-FoFSmN4nBYo1a9PMfgXusxaSAWlllPi9e5k0TtGIUayyeanLilYKJ2fJAzPWMmWy4AAoqid7aDUCKdP21uGVeg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/evm/-/evm-5.0.0.tgz",
+      "integrity": "sha512-JZeIBtB2Z78sWprHPrbf8//QFNRiznniuj6+GRQmU57Mn9azf85m+GvvRbKqqR1Eil0V2LSvglFH738I5igE1w==",
       "dependencies": {
         "@openzeppelin/contracts": "4.8.3"
       },
@@ -1148,12 +1517,12 @@
       }
     },
     "node_modules/@tableland/sdk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-5.2.0.tgz",
-      "integrity": "sha512-tqu6ByCm4oz1Ml/bZBeBYPeEsxW6pqbNY+VGV+PQ+UFpMU+cf4T202hki4s69F2nnE3HpgaPrXPKYD8Z55pU+Q==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@tableland/sdk/-/sdk-6.0.0.tgz",
+      "integrity": "sha512-3gpwiC2XOSUHq0M5kHfSl6mB2vDX9xPb+ZiNuiPzSN3EZaIBsA6IJZzWzlinc6Nnmaxz1V1ZR4sUowMeMF0Hag==",
       "dependencies": {
         "@async-generators/from-emitter": "^0.3.0",
-        "@tableland/evm": "^4.5.0",
+        "@tableland/evm": "^5.0.0",
         "@tableland/sqlparser": "^1.3.0",
         "ethers": "^5.7.2"
       }
@@ -2504,6 +2873,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.19.12",
+        "@esbuild/android-arm": "0.19.12",
+        "@esbuild/android-arm64": "0.19.12",
+        "@esbuild/android-x64": "0.19.12",
+        "@esbuild/darwin-arm64": "0.19.12",
+        "@esbuild/darwin-x64": "0.19.12",
+        "@esbuild/freebsd-arm64": "0.19.12",
+        "@esbuild/freebsd-x64": "0.19.12",
+        "@esbuild/linux-arm": "0.19.12",
+        "@esbuild/linux-arm64": "0.19.12",
+        "@esbuild/linux-ia32": "0.19.12",
+        "@esbuild/linux-loong64": "0.19.12",
+        "@esbuild/linux-mips64el": "0.19.12",
+        "@esbuild/linux-ppc64": "0.19.12",
+        "@esbuild/linux-riscv64": "0.19.12",
+        "@esbuild/linux-s390x": "0.19.12",
+        "@esbuild/linux-x64": "0.19.12",
+        "@esbuild/netbsd-x64": "0.19.12",
+        "@esbuild/openbsd-x64": "0.19.12",
+        "@esbuild/sunos-x64": "0.19.12",
+        "@esbuild/win32-arm64": "0.19.12",
+        "@esbuild/win32-ia32": "0.19.12",
+        "@esbuild/win32-x64": "0.19.12"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
@@ -3394,6 +3801,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.3.tgz",
+      "integrity": "sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/github-from-package": {
@@ -4921,6 +5340,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -5628,6 +6056,25 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/tsx": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.7.2.tgz",
+      "integrity": "sha512-BCNd4kz6fz12fyrgCTEdZHGJ9fWTGeUzXmQysh0RVocDY3h4frk05ZNCXSy4kIenF7y/QnrdiVpTsyNRn6vlAw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.19.10",
+        "get-tsconfig": "^4.7.2"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "build": "npx tsc",
     "start": "node dist/index.js",
     "dev": "NODE_ENV=development npx tsx src/index.ts",
+    "dev:migrate": "NODE_ENV=development RUN_MIGRATION=true npx tsx src/index.ts",
+    "migrate": "RUN_MIGRATION=true node dist/index.js",
     "lint": "eslint '**/*.{js,ts}'",
     "lint:fix": "npm run lint -- --fix",
     "prettier": "prettier '**/*.{js,ts,json,md}' --check",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "npx tsc",
     "start": "node dist/index.js",
+    "dev": "NODE_ENV=development npx tsx src/index.ts",
     "lint": "eslint '**/*.{js,ts}'",
     "lint:fix": "npm run lint -- --fix",
     "prettier": "prettier '**/*.{js,ts,json,md}' --check",
@@ -50,10 +51,11 @@
     "prettier": "^3.0.3",
     "tempy": "^3.1.0",
     "ts-node": "^10.9.2",
+    "tsx": "^4.7.2",
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@tableland/sdk": "^5.2.0",
+    "@tableland/sdk": "^6.0.0",
     "better-sqlite3": "^9.4.1",
     "discord.js": "^14.14.1",
     "dotenv": "^16.4.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ const {
   DISCORD_BOT_TOKEN,
   PRIVATE_KEY,
   NODE_ENV,
+  RUN_MIGRATION,
 } = getEnvVars();
 
 const { vault } = getBasinConfig(NODE_ENV);
@@ -35,7 +36,8 @@ const { vault } = getBasinConfig(NODE_ENV);
 // SQLite database that gets downloaded from the vault
 const signer = new Signer(PRIVATE_KEY);
 const dbPath = join("data", "state.db");
-await init(signer, vault, dbPath);
+const runMigration = RUN_MIGRATION === "true";
+await init(signer, vault, dbPath, runMigration);
 
 // Create a connection to the local SQLite database that stores the latest run
 // information and the latest blocks processed by each chain.

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,10 @@ const {
   DISCORD_WEBHOOK_TOKEN_EXTERNAL,
   DISCORD_BOT_TOKEN,
   PRIVATE_KEY,
+  NODE_ENV,
 } = getEnvVars();
 
-const { vault } = getBasinConfig();
+const { vault } = getBasinConfig(NODE_ENV);
 
 // Initialize the state database with the private key and the path to the
 // SQLite database that gets downloaded from the vault

--- a/src/tbl.ts
+++ b/src/tbl.ts
@@ -23,7 +23,7 @@ const sqlLatestBlocksByChain = (type: ChainType): string => {
       FROM
         system_evm_blocks
       WHERE 
-        chainId != 421613 AND chainId != 5 AND chainId != 3141
+        chainId != 421613 AND chainId != 5 AND chainId != 3141 AND chainId != 420
       GROUP BY
         chainId;
     `);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,6 @@
 import { existsSync, readFileSync } from "fs";
 import dotenv from "dotenv";
-dotenv.config({
-  path: [".env.local", ".env"], // Load .env.local first, then .env
-});
+dotenv.config();
 
 // Defines the interface for `state` table and associated types.
 export interface State {
@@ -64,6 +62,7 @@ export const getEnvVars = (): Record<string, string> => {
     DISCORD_BOT_TOKEN,
     PRIVATE_KEY,
     NODE_ENV,
+    RUN_MIGRATION,
   } = process.env;
   if (
     DISCORD_WEBHOOK_ID_INTERNAL == null ||
@@ -83,6 +82,7 @@ export const getEnvVars = (): Record<string, string> => {
       DISCORD_BOT_TOKEN,
       PRIVATE_KEY,
       NODE_ENV: NODE_ENV ?? "production", // Default to production
+      RUN_MIGRATION: RUN_MIGRATION ?? "false", // Default to false
     };
   }
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync } from "fs";
 import dotenv from "dotenv";
-dotenv.config();
+dotenv.config({
+  path: [".env.local", ".env"], // Load .env.local first, then .env
+});
 
 // Defines the interface for `state` table and associated types.
 export interface State {
@@ -61,6 +63,7 @@ export const getEnvVars = (): Record<string, string> => {
     DISCORD_WEBHOOK_TOKEN_EXTERNAL,
     DISCORD_BOT_TOKEN,
     PRIVATE_KEY,
+    NODE_ENV,
   } = process.env;
   if (
     DISCORD_WEBHOOK_ID_INTERNAL == null ||
@@ -79,16 +82,19 @@ export const getEnvVars = (): Record<string, string> => {
       DISCORD_WEBHOOK_TOKEN_EXTERNAL,
       DISCORD_BOT_TOKEN,
       PRIVATE_KEY,
+      NODE_ENV: NODE_ENV ?? "production", // Default to production
     };
   }
 };
 
 // Get basin config file for the `vault` parameter.
-export const getBasinConfig = (): Record<string, string> => {
-  if (!existsSync("basin-config.json")) {
+export const getBasinConfig = (env: string): Record<string, string> => {
+  const configFile =
+    env === "production" ? "basin-config.json" : "basin-config-dev.json";
+  if (!existsSync(configFile)) {
     throw new Error("basin config file not found");
   }
-  const data = readFileSync("basin-config.json", "utf8");
+  const data = readFileSync(configFile, "utf8");
   if (data === "") {
     throw new Error("basin config file not set");
   } else {


### PR DESCRIPTION
## Summary

- Adds retry logic & backoff for getting vaults from the HTTP API.
- Adds a migration step in case Tableland chains are altered.
- Also implements dev-only environment flow for testing purposes.

## Details

The Basin HTTP API uses Glif's Calibration RPC under the hood, which started [throwing errors](https://github.com/tablelandnetwork/discord-sql-logs/actions/runs/8561833906/job/23463913880#step:7:20) for `EVM error: error sending request for url (https://api.calibration.node.glif.io/rpc/v1): connection closed before message completed`. This is now handled with retry logic if the specific error is seen.

Also, the vault stores SQLite databases that store the latest blocks fetched for supported chains. If Tableland alters the supported chains, then a new db needs to be created so that the Discord bot doesn't keep fetching SQL logs for old chains. A `migrate` script and `migration` action have been added to support this, which just creates a fresh SQLite db.